### PR TITLE
README.md has a typo when importing the module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Include "animate.css" from https://daneden.github.io/animate.css/
 ## Usage:
 
 ```
-import ScrollEffect from 'react-scroll-effect';
+import ScrollEffect from 'react-scroll-effects';
 
 <ScrollEffect animate="fadeInUp">
   test 1


### PR DESCRIPTION
Instructions in the `README.md` have a typo.
